### PR TITLE
use WithDetectLocalBinary function on windows

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -759,6 +759,10 @@ func (cli *DaemonCli) getContainerdDaemonOpts() ([]supervisor.DaemonOpt, error) 
 		opts = append(opts, supervisor.WithCRIDisabled())
 	}
 
+	if runtime.GOOS == "windows" {
+		opts = append(opts, supervisor.WithDetectLocalBinary())
+	}
+
 	return opts, nil
 }
 
@@ -1005,6 +1009,7 @@ func (cli *DaemonCli) initContainerd(ctx context.Context) (func(time.Duration) e
 		system.InitContainerdRuntime(cli.ContainerdAddr)
 		return nil, nil
 	}
+
 	if runtime.GOOS == "windows" && cli.DefaultRuntime != config.WindowsV2RuntimeName {
 		return nil, nil
 	}

--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/containerd/log"
 	"github.com/docker/docker/daemon/config"
-	"github.com/docker/docker/libcontainerd/supervisor"
 	"golang.org/x/sys/windows"
 	"os"
 )
@@ -53,17 +52,6 @@ func notifyShutdown(err error) {
 		}
 		service.stopped(err)
 	}
-}
-
-func (cli *DaemonCli) getPlatformContainerdDaemonOpts() ([]supervisor.DaemonOpt, error) {
-	opts := []supervisor.DaemonOpt{
-		// On Windows, it first checks if a containerd binary is found in the same
-		// directory as the dockerd binary. If found, this binary takes precedence
-		// over containerd binaries installed in $PATH.
-		supervisor.WithDetectLocalBinary(),
-	}
-
-	return opts, nil
 }
 
 // setupConfigReloadTrap configures a Win32 event to reload the configuration.

--- a/libcontainerd/supervisor/remote_daemon_options.go
+++ b/libcontainerd/supervisor/remote_daemon_options.go
@@ -62,7 +62,8 @@ func WithDetectLocalBinary() DaemonOpt {
 			return errors.Errorf("local containerd path found (%s), but is a directory", localBinary)
 		}
 		r.daemonPath = localBinary
-		r.logger.WithError(err).WithField("binary", localBinary).Debug("failed to look up local containerd binary; using default binary")
+		r.logger.WithField("daemon path", r.daemonPath).Debug("Local containerd daemon found.")
+
 		return nil
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

`WithDetectLocalBinary` func doesn't seem to be used. Make use of `WithDetectLocalBinary` to detect and use local containerd binary.


**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

